### PR TITLE
fix: fake encyclopedia articles for fake cards

### DIFF
--- a/models/card.py
+++ b/models/card.py
@@ -4,7 +4,6 @@ import peewee
 from playhouse.shortcuts import model_to_dict as mtd_original
 from .base import InGameModel
 from .player import Player
-from .encyclopedia import Article
 from .counters import AffinityTopic, Color
 
 
@@ -60,10 +59,6 @@ class Card(InGameModel):
 
     storyline = peewee.CharField(default="none")
     storyline_index = peewee.IntegerField(default=0)
-
-    encyclopedia_article = peewee.ForeignKeyField(
-        Article, null=True, unique=False, backref="cards"
-    )
 
     image = peewee.FixedCharField(default="", max_length=50)  # image url
 

--- a/models/encyclopedia.py
+++ b/models/encyclopedia.py
@@ -3,6 +3,7 @@ import json
 import peewee
 
 from .base import InGameModel
+from .card import Card
 
 
 class Article(InGameModel):
@@ -14,12 +15,13 @@ class Article(InGameModel):
     fake_type_ = peewee.CharField(null=True)
     fake_author = peewee.CharField(null=True)
     is_fake = peewee.BooleanField(null=True)
+    card = peewee.ForeignKeyField(
+        Card, null=True, unique=True, backref="encyclopedia_article"
+    )
 
     @classmethod
     def import_from_json(cls, json_dict=None, json_path=None, defaults=None):
         """First creates the original cards, then the fakes"""
-        from .card import Card
-
         if not json_dict:
             with open(json_path) as infile:
                 json_dict = json.load(infile)
@@ -42,9 +44,9 @@ class Article(InGameModel):
 
         super().import_from_json(json_dict=new_, defaults=defaults)
 
-    def render(self):
-        """Returns either the true or fake article"""
-        if self.is_fake and self.fake_content and self.fake_type_ and self.fake_author:
+    def render(self, fake: bool):
+        """Returns either the true or fake article depending on the `fake` argument"""
+        if fake and self.fake_content and self.fake_type_ and self.fake_author:
             return {
                 "title": self.title,
                 "content": self.fake_content,

--- a/models/player.py
+++ b/models/player.py
@@ -8,7 +8,6 @@ from constants import (
 )
 from .utils import model_to_dict
 from .base import InGameModel, Round, Game
-from .encyclopedia import Article
 from .counters import AffinityTopic, Color
 from exceptions import NotAllowed, NotFound
 from functools import lru_cache
@@ -345,16 +344,15 @@ class Player(InGameModel):
     def action_encyclopedia_search(self, card_id):
         """Returns this card's encyclopedia article"""
         from .card import Card
+        from .encyclopedia import Article
 
         card = Card.select().where(Card.id_ == card_id, Card.game == self.game).first()
-        article = (
-            Article.select()
-            .where(Article.title == card.description, Article.game == card.game)
-            .first()
-        )
-        # article = card.encyclopedia_article
+        if card.fake:
+            article = card.original.encyclopedia_article.first()
+        else:
+            article = card.encyclopedia_article.first()
         if article:
-            return article.render()
+            return article.render(fake=card.fake)
         return {}
 
     def all_actions(self):


### PR DESCRIPTION
## Changes made:
1. Moved foreign key from `card.encyclopedia_article` to `encyclopedia_article.card` (this makes it easier to load the data)
2. Fixed logic to display fake article if the search is performed on a fake card

## How the foreign key linking is supposed to work:
* Each encyclopedia article has 2 versions - fake and real. Both are in the same row. Fields `content` and `author`  together form the real version, fields `fake_content` and `fake_author` together form the fake version.
* The article has a foreign key called `card` - which points to the card for which the real version of this article will be displayed (basically points to the true card).
* So if the user does an encyclopedia search on the true card, we simply render `card.encyclopedia_article.first()
`* each fake card has an `original` foreign key which points to the true version of the fake card.
* If a user performs an encyclopedia search on a fake card, we render the `fake_card.original.encyclopedia_article.first()`

---
Tested using python shell. Attaching a screenshot of me manually invoking `player.action_encyclopedia_search` with two cards - first the fake card and then the original (true) version of the fake card, and you see that first the fake version of the article is rendered, then the real one. 

![image](https://user-images.githubusercontent.com/527598/230767904-67a6e17d-6c21-4ea9-a73d-a5d8f9e50949.png)

The 2nd screenshot is of the encyclopedia article table - you can see that the articles rendered above are indeed two versions (true and fake) of the same article.

![image](https://user-images.githubusercontent.com/527598/230767948-f595ae98-1511-4b52-b5ba-bb38a01f7d49.png)
