### PR TITLE
Cancel related fixes

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -10,7 +10,7 @@ VIRAL_SPIRAL_BIAS_COUNT = 5
 
 # If the affinity towards any topic reaches 3, the player receives the
 # cancel power
-CANCELLING_AFFINITY_COUNT = 0
+CANCELLING_AFFINITY_COUNT = 1
 # If True, all players will be asked to vote instead of just the affinity
 CANCEL_VOTE_ALL_PLAYERS = False
 


### PR DESCRIPTION
Currently as the code stands the cancel power is not working properly. I have identified a few main causes of the same, I'm listing the same here: 

1. Firstly currently as the code stands, only if a player is cancelled in the PREVIOUS ROUND then their turn is skipped in the current round, a reference to this can be found here: https://github.com/tattle-made/viral-spiral-backend/blob/6717dc65e1824f22fd82cc07aea030795b4cb237/models/powers.py#L84
2. Secondly, even if their turn is skipped, the way in which the `do_round` function works in `main_loop/base.py`, they will still draw a card regardless of their turn being skipped in the current round because of the `finish_round` function repeating twice: https://github.com/tattle-made/viral-spiral-backend/blob/6717dc65e1824f22fd82cc07aea030795b4cb237/main_loop/base.py#L87

Since the intended effect of the cancel power is to cancel the VERY next turn of a player, and not the turn in the next round, a mechanism needed to be put in place which checks for skipping the player in the same round IF a player has cancelled them in this very round as well as checking for skipping them in the next round after being successfully cancelled if they were not skipped in the last round. Secondly the double usage of a `finish round` function essentially let the player be cancelled and still draw a card, this needed to be fixed