### PR TITLE
Fix: fixed turn order bug in cancel superpower

### DIFF
--- a/main_loop/base.py
+++ b/main_loop/base.py
@@ -48,6 +48,10 @@ class GameRunner(ABC):
         # If this player is pending cancellation punishment then skip them
         if CancelStatus.cancelled(drawing_player):
             print(str(drawing_player) + " was cancelled")
+            # update the sequence of players regardless of the player being cancelled for the turn order to be maintained
+            Player.update(sequence=Player.sequence + 100, current=True).where( 
+                Player.id_ == drawing_player.id_ 
+            ).execute()
             return False
 
         while True:
@@ -64,8 +68,6 @@ class GameRunner(ABC):
             with db:
                 for player in self.players.iterator():
                     # TODO see if you can optimise this in a single query
-                    # if CancelStatus.cancelled(player):
-                    #     continue
                     if (card_instance := player.get_queued_card_instance()) is not None:
                         self.invoke_player_action(player, card_instance)
                         done = False
@@ -83,6 +85,9 @@ class GameRunner(ABC):
     def do_round(self, drawing_player: Player, full_round: FullRound):
         """Performs a round in `game` with `drawing_player` drawing a card"""
         flag = self.finish_round(drawing_player)  # Finish any older rounds
+        # -- this checks to see if this player has any already queued card instance
+        # if yes, then they will get a turn and the game will wait till that player takes an action with it
+        # this card instance is assigned at the previous round when the below code runs
         if flag:
             with db:
                 card_instance = self.game.draw(drawing_player, full_round=full_round)
@@ -109,6 +114,7 @@ class GameRunner(ABC):
                 full_round = FullRound.create(game=self.game)
                 players = [player for player in self.players]
                 ordered_players = sorted(players, key=lambda player: player.sequence)
+                
             for player in ordered_players:
                 # Re fetch the player once
                 player = self.players.select().where(Player.id_ == player.id_).first()

--- a/models/powers.py
+++ b/models/powers.py
@@ -90,7 +90,7 @@ class CancelStatus(InGameModel):
         
 
         for round_ in prev_rounds:
-            print(round_.id_)
+            # print(round_.id_)
             status = (
                 CancelStatus.select()
                 .where(CancelStatus.round_id == round_.id_)
@@ -101,6 +101,7 @@ class CancelStatus(InGameModel):
             status_bool= True if status and status.final_status else False
             if status_bool:
                 CancelStatus.update(power_executed=1).where(CancelStatus.round_id == round_.id_).where(CancelStatus.against_id == player.id_).execute()
+                print("status bool was returned as true!")
                 return status_bool
 
 
@@ -108,7 +109,7 @@ class CancelStatus(InGameModel):
             
         
         for round_ in current_rounds:
-            print(round_.id_)
+            # print(round_.id_)
             status = (
                 CancelStatus.select()
                 .where(CancelStatus.round_id == round_.id_)
@@ -119,13 +120,13 @@ class CancelStatus(InGameModel):
             status_bool = True if status and status.final_status else False
             if status_bool:
                 CancelStatus.update(power_executed=1).where(CancelStatus.round_id == round_.id_).where(CancelStatus.against_id == player.id_).execute()
+                print("status bool was returned as true!")
                 return status_bool
             
             
-        print("status_bool returned as false")  
+         
         return status_bool
-        # print("Just returning false")
-        # return False
+       
 
     @classmethod
     def initiate(cls, initiator: Player, against: Player, topic: AffinityTopic):
@@ -141,7 +142,7 @@ class CancelStatus(InGameModel):
         return cancel_status
 
     # This method is to be called everytime a new vote is casted. If all the votes aren't casted yet, final_status remains unchanged
-    @classmethod
+    @classmethod 
     def set_final_status(cls, cancel_status_id: str):
         from itertools import filterfalse
 

--- a/test/_test_power_pass.py
+++ b/test/_test_power_pass.py
@@ -1,0 +1,96 @@
+# Prerequisite
+# Modify constants.py and set FAKE_NEWS_BIAS_COUNT to -1
+
+from models import (
+    Game,
+    Player,
+    Card,
+    CardInstance,
+    Score,
+    FullRound,
+    PlayerPower,
+    utils,
+)
+from main_loop import websocket
+from random import random
+from itertools import filterfalse
+
+# Create Game
+for progress in Game.new(
+    player_count=4,
+    colors_filepath="config_jsons/example1/colors.json",
+    topics_filepath="config_jsons/example1/topics.json",
+    password="asdf",
+    draw_fn_name="first",
+    cards_filepath="config_jsons/example1/cards.json",
+    encyclopedia_filepath="config_jsons/example1/articles.json",
+):
+    if progress["type"] == "message":
+        print(progress["payload"])
+    if progress["type"] == "result":
+        game = progress["payload"]
+
+print("Game Created : ", game.name)
+
+playernames = ["adhiraj", "aman", "krys", "farah"]
+players = game.player_set
+
+# join game
+for name in playernames:
+    player = game.get_unclaimed_player(name)
+    player.name = name
+    Score.initialize(game, player)
+    player.save()
+
+
+full_round = FullRound.create(game=game)
+players = [player for player in players]
+ordered_players = sorted(players, key=lambda player: player.sequence)
+
+
+current_player = ordered_players[0]
+current_player.current = True
+current_player.save()
+game.update_powers()
+
+
+for player in ordered_players:
+    print(player.name, player.sequence, player.current)
+
+# draw a card
+card_instance = game.draw(current_player, full_round=full_round)
+if not card_instance:
+    raise Exception("Out of cards!")
+print(card_instance.card.fake, card_instance.card.description)
+cardId = card_instance.card.id_
+cardInstanceId = card_instance.id_
+fakeCardCount = len(card_instance.card.fakes)
+if fakeCardCount != 0:
+    fakeCardId = card_instance.card.fakes[0].id_
+else:
+    raise Exception("No fake card present")
+
+game.update_powers()
+
+recipients = [rec.name for rec in card_instance.allowed_recipients()]
+allowed_actions = current_player.allowed_actions(card_instance)
+
+
+print("card Id : ", cardId)
+print("card instance id : ", cardInstanceId)
+print("fake card count : ", fakeCardCount)
+print("fake card id : ", fakeCardId)
+print("recipients : ", recipients)
+print("allowed actions : ", allowed_actions)
+
+
+
+
+# invoke turn to fake power
+new_card_instance = current_player.action_pass_card(cardInstanceId, str(recipients[0]))
+print(new_card_instance)
+
+
+# pass to next player
+
+# assert everyone's score


### PR DESCRIPTION
The turn order does not get changed now whenever the cancel superpower is used. This resolves all the bugs in the cancel superpower and effectively makes it functional in the backend