### PR TITLE
feat: updated cancel to make voting an toggle-able feature

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -11,6 +11,8 @@ VIRAL_SPIRAL_BIAS_COUNT = 5
 # If the affinity towards any topic reaches 3, the player receives the
 # cancel power
 CANCELLING_AFFINITY_COUNT = 1
+# if true, cancel has the polling mechanic
+CANCELLING_ALLOW_POLL = False
 # If True, all players will be asked to vote instead of just the affinity
 CANCEL_VOTE_ALL_PLAYERS = False
 

--- a/main_loop/base.py
+++ b/main_loop/base.py
@@ -5,6 +5,7 @@ import sys
 from abc import ABC, abstractmethod
 from typing import Callable
 from models import db, Game, Player, CardInstance, CancelStatus, CancelVote, FullRound
+from constants import CANCELLING_ALLOW_POLL
 
 
 class GameRunner(ABC):
@@ -71,7 +72,7 @@ class GameRunner(ABC):
                     if (card_instance := player.get_queued_card_instance()) is not None:
                         self.invoke_player_action(player, card_instance)
                         done = False
-                    if (pending_vote := player.get_pending_cancel_vote()) is not None:
+                    if ((pending_vote := player.get_pending_cancel_vote()) is not None) and CANCELLING_ALLOW_POLL:
                         self.invoke_vote(player, pending_vote)
                         done = False
                     # TODO see if you really need to update powers after each turn

--- a/models/player.py
+++ b/models/player.py
@@ -422,7 +422,7 @@ class Player(InGameModel):
             CancelVote.pending_votes(round_=self.game.current_round)
             .where(CancelVote.voter == self)
             .exists()
-        ):
+        ) and CANCELLING_AFFINITY_COUNT:
             allowed_actions.append("vote_cancel")
 
         return allowed_actions


### PR DESCRIPTION
Added a variable called CANCELLING_ALLOW_VOTE in order to toggle whether voting is optionally allowed or not when the cancel power is executed